### PR TITLE
feat: tap date in DayNavigator to jump to today

### DIFF
--- a/src/app/src-rn/__tests__/utils/dateUtils.test.ts
+++ b/src/app/src-rn/__tests__/utils/dateUtils.test.ts
@@ -5,6 +5,7 @@ describe('dateUtils', () => {
   let localDateKey: typeof import('../../utils/dateUtils').localDateKey;
   let isSameDay: typeof import('../../utils/dateUtils').isSameDay;
   let isOrderingCutoff: typeof import('../../utils/dateUtils').isOrderingCutoff;
+  let findNearestDate: typeof import('../../utils/dateUtils').findNearestDate;
 
   beforeEach(() => {
     jest.resetModules();
@@ -15,6 +16,7 @@ describe('dateUtils', () => {
     localDateKey = mod.localDateKey;
     isSameDay = mod.isSameDay;
     isOrderingCutoff = mod.isOrderingCutoff;
+    findNearestDate = mod.findNearestDate;
   });
 
   describe('formatGourmetDate', () => {
@@ -130,6 +132,54 @@ describe('dateUtils', () => {
       jest.setSystemTime(new Date('2026-02-10T13:00:00Z'));
       const futureDate = new Date(2026, 1, 11); // Feb 11
       expect(isOrderingCutoff(futureDate)).toBe(false);
+    });
+  });
+
+  describe('findNearestDate', () => {
+    it('returns null for empty dates array', () => {
+      expect(findNearestDate([], new Date(2026, 1, 10))).toBeNull();
+    });
+
+    it('returns exact match when target date exists', () => {
+      const dates = [
+        new Date(2026, 1, 9),
+        new Date(2026, 1, 10),
+        new Date(2026, 1, 11),
+      ];
+      const result = findNearestDate(dates, new Date(2026, 1, 10));
+      expect(result!.getDate()).toBe(10);
+    });
+
+    it('returns nearest future date over closer past date', () => {
+      const dates = [
+        new Date(2026, 1, 9),
+        new Date(2026, 1, 12),
+      ];
+      // Target is Feb 10: Feb 9 is closer (1 day) but Feb 12 is future
+      const result = findNearestDate(dates, new Date(2026, 1, 10));
+      expect(result!.getDate()).toBe(12);
+    });
+
+    it('falls back to latest past date when no future dates exist', () => {
+      const dates = [
+        new Date(2026, 1, 5),
+        new Date(2026, 1, 8),
+      ];
+      // Target is Feb 10, no future dates — fall back to nearest past (Feb 8)
+      const result = findNearestDate(dates, new Date(2026, 1, 10));
+      expect(result!.getDate()).toBe(8);
+    });
+
+    it('works with single future date in list', () => {
+      const dates = [new Date(2026, 1, 15)];
+      const result = findNearestDate(dates, new Date(2026, 1, 10));
+      expect(result!.getDate()).toBe(15);
+    });
+
+    it('works with single past date in list', () => {
+      const dates = [new Date(2026, 1, 5)];
+      const result = findNearestDate(dates, new Date(2026, 1, 10));
+      expect(result!.getDate()).toBe(5);
     });
   });
 });

--- a/src/app/src-rn/components/DayNavigator.tsx
+++ b/src/app/src-rn/components/DayNavigator.tsx
@@ -1,6 +1,6 @@
 import { Platform, Pressable, StyleSheet, Text, View } from 'react-native';
 import { AdaptiveBlurView } from './AdaptiveBlurView';
-import { formatDisplayDate } from '../utils/dateUtils';
+import { formatDisplayDate, findNearestDate } from '../utils/dateUtils';
 import { useTheme } from '../theme/useTheme';
 import { Colors } from '../theme/colors';
 import { circleButton } from '../theme/platformStyles';
@@ -30,6 +30,13 @@ export function DayNavigator({ dates, selectedDate, onSelectDate }: DayNavigator
     }
   };
 
+  const goToToday = () => {
+    const nearest = findNearestDate(dates, new Date());
+    if (nearest) {
+      onSelectDate(nearest);
+    }
+  };
+
   const content = (
     <View style={styles.container}>
       <Pressable
@@ -40,14 +47,14 @@ export function DayNavigator({ dates, selectedDate, onSelectDate }: DayNavigator
         <Text style={styles.arrowText}>&#x276E;</Text>
       </Pressable>
 
-      <View style={styles.dateContainer}>
+      <Pressable style={styles.dateContainer} onPress={goToToday}>
         <Text style={styles.dateText}>
           {formatDisplayDate(selectedDate)}
         </Text>
         <Text style={styles.pageText}>
           {currentIndex + 1} / {dates.length}
         </Text>
-      </View>
+      </Pressable>
 
       <Pressable
         onPress={goForward}

--- a/src/app/src-rn/utils/dateUtils.ts
+++ b/src/app/src-rn/utils/dateUtils.ts
@@ -80,3 +80,39 @@ export function isOrderingCutoff(menuDate: Date): boolean {
   const minute = Number(parts.find((p) => p.type === 'minute')?.value ?? 0);
   return hour * 60 + minute >= 12 * 60 + 30;
 }
+
+/**
+ * Find the nearest future date (>= target day) in a list.
+ * Falls back to the latest past date if no future dates exist.
+ * Returns null if list is empty.
+ */
+export function findNearestDate(dates: Date[], target: Date): Date | null {
+  if (dates.length === 0) return null;
+
+  const targetStart = new Date(target.getFullYear(), target.getMonth(), target.getDate());
+
+  let nearestFuture: Date | null = null;
+  let futureDiff = Infinity;
+  let latestPast: Date | null = null;
+  let pastDiff = Infinity;
+
+  for (const date of dates) {
+    const dateStart = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+    const diff = dateStart.getTime() - targetStart.getTime();
+
+    if (diff >= 0) {
+      if (diff < futureDiff) {
+        futureDiff = diff;
+        nearestFuture = date;
+      }
+    } else {
+      const absDiff = -diff;
+      if (absDiff < pastDiff) {
+        pastDiff = absDiff;
+        latestPast = date;
+      }
+    }
+  }
+
+  return nearestFuture ?? latestPast;
+}


### PR DESCRIPTION
## Summary
- Tapping the date text in the mobile DayNavigator now jumps to the nearest future menu date (or latest past date if no future dates exist)
- Adds `findNearestDate` utility to `dateUtils.ts` with 6 tests

Closes #8

## Test plan
- [x] 205 tests pass (`npm test`)
- [ ] Verify on iOS Simulator: navigate away from today, tap date text, confirm it jumps to nearest future date
- [ ] Verify arrow navigation still works
- [ ] Verify swipe gestures still work