### PR TITLE
Disable cancel button after 9am cutoff

### DIFF
--- a/src/app/app/(tabs)/orders.tsx
+++ b/src/app/app/(tabs)/orders.tsx
@@ -128,7 +128,7 @@ export default function OrdersScreen() {
                   menuDescription={menuDescriptions.get(`${item.date.toDateString()}|${item.title}`)}
                   isCancelling={cancellingId === item.positionId}
                   onCancel={() => handleCancel(item.positionId, item.title)}
-                  canCancel={activeTab === 'upcoming' && cancellingId === null}
+                  canCancel={activeTab === 'upcoming'}
                 />
               )}
               ListEmptyComponent={
@@ -202,7 +202,7 @@ export default function OrdersScreen() {
               menuDescription={menuDescriptions.get(`${item.date.toDateString()}|${item.title}`)}
               isCancelling={cancellingId === item.positionId}
               onCancel={() => handleCancel(item.positionId, item.title)}
-              canCancel={activeTab === 'upcoming' && cancellingId === null}
+              canCancel={activeTab === 'upcoming'}
             />
           )}
           ListEmptyComponent={

--- a/src/app/app/(tabs)/orders.tsx
+++ b/src/app/app/(tabs)/orders.tsx
@@ -128,7 +128,7 @@ export default function OrdersScreen() {
                   menuDescription={menuDescriptions.get(`${item.date.toDateString()}|${item.title}`)}
                   isCancelling={cancellingId === item.positionId}
                   onCancel={() => handleCancel(item.positionId, item.title)}
-                  canCancel={activeTab === 'upcoming'}
+                  canCancel={activeTab === 'upcoming' && cancellingId === null}
                 />
               )}
               ListEmptyComponent={
@@ -202,7 +202,7 @@ export default function OrdersScreen() {
               menuDescription={menuDescriptions.get(`${item.date.toDateString()}|${item.title}`)}
               isCancelling={cancellingId === item.positionId}
               onCancel={() => handleCancel(item.positionId, item.title)}
-              canCancel={activeTab === 'upcoming'}
+              canCancel={activeTab === 'upcoming' && cancellingId === null}
             />
           )}
           ListEmptyComponent={

--- a/src/app/src-rn/__tests__/utils/dateUtils.test.ts
+++ b/src/app/src-rn/__tests__/utils/dateUtils.test.ts
@@ -221,5 +221,19 @@ describe('dateUtils', () => {
       const futureDate = new Date(2026, 1, 11); // Feb 11
       expect(isCancellationCutoff(futureDate)).toBe(false);
     });
+
+    it('returns true for today at 09:00 Vienna time (CEST / summer)', () => {
+      // Aug 10 2026, 09:00 Vienna CEST (UTC+2) -> UTC 07:00
+      jest.setSystemTime(new Date('2026-08-10T07:00:00Z'));
+      const orderDate = new Date(2026, 7, 10); // Aug 10
+      expect(isCancellationCutoff(orderDate)).toBe(true);
+    });
+
+    it('returns false for today before 09:00 Vienna time (CEST / summer)', () => {
+      // Aug 10 2026, 08:59 Vienna CEST (UTC+2) -> UTC 06:59
+      jest.setSystemTime(new Date('2026-08-10T06:59:00Z'));
+      const orderDate = new Date(2026, 7, 10);
+      expect(isCancellationCutoff(orderDate)).toBe(false);
+    });
   });
 });

--- a/src/app/src-rn/__tests__/utils/dateUtils.test.ts
+++ b/src/app/src-rn/__tests__/utils/dateUtils.test.ts
@@ -6,6 +6,7 @@ describe('dateUtils', () => {
   let isSameDay: typeof import('../../utils/dateUtils').isSameDay;
   let isOrderingCutoff: typeof import('../../utils/dateUtils').isOrderingCutoff;
   let findNearestDate: typeof import('../../utils/dateUtils').findNearestDate;
+  let isCancellationCutoff: typeof import('../../utils/dateUtils').isCancellationCutoff;
 
   beforeEach(() => {
     jest.resetModules();
@@ -17,6 +18,7 @@ describe('dateUtils', () => {
     isSameDay = mod.isSameDay;
     isOrderingCutoff = mod.isOrderingCutoff;
     findNearestDate = mod.findNearestDate;
+    isCancellationCutoff = mod.isCancellationCutoff;
   });
 
   describe('formatGourmetDate', () => {
@@ -180,6 +182,44 @@ describe('dateUtils', () => {
       const dates = [new Date(2026, 1, 5)];
       const result = findNearestDate(dates, new Date(2026, 1, 10));
       expect(result!.getDate()).toBe(5);
+    });
+  });
+
+  describe('isCancellationCutoff', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('returns false for today before 09:00 Vienna time', () => {
+      // Feb 10 2026, 08:59 Vienna (CET = UTC+1) -> UTC 07:59
+      jest.setSystemTime(new Date('2026-02-10T07:59:00Z'));
+      const orderDate = new Date(2026, 1, 10);
+      expect(isCancellationCutoff(orderDate)).toBe(false);
+    });
+
+    it('returns true for today at 09:00 Vienna time', () => {
+      // Feb 10 2026, 09:00 Vienna (CET = UTC+1) -> UTC 08:00
+      jest.setSystemTime(new Date('2026-02-10T08:00:00Z'));
+      const orderDate = new Date(2026, 1, 10);
+      expect(isCancellationCutoff(orderDate)).toBe(true);
+    });
+
+    it('returns true for today after 09:00 Vienna time', () => {
+      // Feb 10 2026, 10:00 Vienna (CET = UTC+1) -> UTC 09:00
+      jest.setSystemTime(new Date('2026-02-10T09:00:00Z'));
+      const orderDate = new Date(2026, 1, 10);
+      expect(isCancellationCutoff(orderDate)).toBe(true);
+    });
+
+    it('returns false for a future date', () => {
+      // Current time: Feb 10 2026, 14:00 Vienna -> UTC 13:00
+      jest.setSystemTime(new Date('2026-02-10T13:00:00Z'));
+      const futureDate = new Date(2026, 1, 11); // Feb 11
+      expect(isCancellationCutoff(futureDate)).toBe(false);
     });
   });
 });

--- a/src/app/src-rn/components/OrderItem.tsx
+++ b/src/app/src-rn/components/OrderItem.tsx
@@ -1,6 +1,6 @@
 import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native';
 import { GourmetOrderedMenu } from '../types/order';
-import { formatDisplayDate } from '../utils/dateUtils';
+import { formatDisplayDate, isCancellationCutoff } from '../utils/dateUtils';
 import { useFlatStyle, isCompactDesktop } from '../utils/platform';
 import { useTheme } from '../theme/useTheme';
 import { Colors } from '../theme/colors';
@@ -17,6 +17,8 @@ interface OrderItemProps {
 export function OrderItem({ order, menuDescription, isCancelling, onCancel, canCancel }: OrderItemProps) {
   const { colors } = useTheme();
   const styles = createStyles(colors);
+  const cutoff = isCancellationCutoff(order.date);
+  const disabled = cutoff || isCancelling;
 
   return (
     <View style={[styles.container, isCancelling && styles.containerCancelling]}>
@@ -42,11 +44,12 @@ export function OrderItem({ order, menuDescription, isCancelling, onCancel, canC
             <ActivityIndicator size="small" color={colors.error} style={styles.cancelButton} />
           ) : (
             <Pressable
-              style={styles.cancelButton}
+              style={[styles.cancelButton, cutoff && styles.cancelButtonDisabled]}
               onPress={onCancel}
               hitSlop={8}
+              disabled={disabled}
             >
-              <Text style={styles.cancelX}>&#x2715;</Text>
+              <Text style={[styles.cancelX, cutoff && styles.cancelXDisabled]}>&#x2715;</Text>
             </Pressable>
           )
         )}
@@ -123,9 +126,17 @@ const createStyles = (c: Colors) =>
       borderWidth: useFlatStyle ? 1 : 0.5,
       borderColor: c.error,
     },
+    cancelButtonDisabled: {
+      opacity: 0.4,
+      borderColor: c.textTertiary,
+      backgroundColor: useFlatStyle ? c.surfaceVariant : c.glassSurfaceVariant,
+    },
     cancelX: {
       fontSize: 16,
       fontWeight: '700',
       color: c.error,
+    },
+    cancelXDisabled: {
+      color: c.textTertiary,
     },
   });

--- a/src/app/src-rn/components/OrderItem.tsx
+++ b/src/app/src-rn/components/OrderItem.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from 'react';
 import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native';
 import { GourmetOrderedMenu } from '../types/order';
 import { formatDisplayDate, isCancellationCutoff } from '../utils/dateUtils';
@@ -17,8 +18,18 @@ interface OrderItemProps {
 export function OrderItem({ order, menuDescription, isCancelling, onCancel, canCancel }: OrderItemProps) {
   const { colors } = useTheme();
   const styles = createStyles(colors);
-  const cutoff = isCancellationCutoff(order.date);
-  const disabled = cutoff || isCancelling;
+  const [cutoff, setCutoff] = useState(() => isCancellationCutoff(order.date));
+
+  useEffect(() => {
+    if (cutoff) return; // already locked
+    const timer = setInterval(
+      () => setCutoff(isCancellationCutoff(order.date)),
+      30_000, // re-check every 30s
+    );
+    return () => clearInterval(timer);
+  }, [order.date, cutoff]);
+
+  const disabled = cutoff;
 
   return (
     <View style={[styles.container, isCancelling && styles.containerCancelling]}>

--- a/src/app/src-rn/store/orderStore.ts
+++ b/src/app/src-rn/store/orderStore.ts
@@ -51,6 +51,7 @@ export const useOrderStore = create<OrderState>((set, get) => ({
   },
 
   cancelOrder: async (positionId: string) => {
+    if (get().cancellingId !== null) return;
     set({ cancellingId: positionId, error: null });
     try {
       const api = useAuthStore.getState().api;

--- a/src/app/src-rn/utils/dateUtils.ts
+++ b/src/app/src-rn/utils/dateUtils.ts
@@ -61,24 +61,39 @@ export function isSameDay(a: Date, b: Date): boolean {
 }
 
 /**
- * Check if ordering is blocked for a given menu date.
- * Today's menu cannot be ordered after 12:30 Europe/Vienna time.
- * Future dates are never blocked.
+ * Get current Vienna time as total minutes since midnight.
  */
-export function isOrderingCutoff(menuDate: Date): boolean {
-  const now = new Date();
-  if (!isSameDay(menuDate, now)) return false;
-
+function viennaMinutes(): number {
   const fmt = new Intl.DateTimeFormat('en-US', {
     timeZone: 'Europe/Vienna',
     hour: 'numeric',
     minute: 'numeric',
     hour12: false,
   });
-  const parts = fmt.formatToParts(now);
+  const parts = fmt.formatToParts(new Date());
   const hour = Number(parts.find((p) => p.type === 'hour')?.value ?? 0);
   const minute = Number(parts.find((p) => p.type === 'minute')?.value ?? 0);
-  return hour * 60 + minute >= 12 * 60 + 30;
+  return hour * 60 + minute;
+}
+
+/**
+ * Check if ordering is blocked for a given menu date.
+ * Today's menu cannot be ordered after 12:30 Europe/Vienna time.
+ * Future dates are never blocked.
+ */
+export function isOrderingCutoff(menuDate: Date): boolean {
+  if (!isSameDay(menuDate, new Date())) return false;
+  return viennaMinutes() >= 12 * 60 + 30;
+}
+
+/**
+ * Check if cancellation is blocked for a given order date.
+ * Today's order cannot be cancelled after 09:00 Europe/Vienna time.
+ * Future dates are never blocked.
+ */
+export function isCancellationCutoff(orderDate: Date): boolean {
+  if (!isSameDay(orderDate, new Date())) return false;
+  return viennaMinutes() >= 9 * 60;
 }
 
 /**

--- a/src/app/src-rn/utils/dateUtils.ts
+++ b/src/app/src-rn/utils/dateUtils.ts
@@ -76,13 +76,22 @@ function viennaMinutes(): number {
   return hour * 60 + minute;
 }
 
+/** Get today's date in Vienna timezone. */
+function viennaToday(): Date {
+  const viennaDateStr = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Europe/Vienna',
+  }).format(new Date()); // yields "YYYY-MM-DD"
+  const [y, m, d] = viennaDateStr.split('-').map(Number);
+  return new Date(y, m - 1, d);
+}
+
 /**
  * Check if ordering is blocked for a given menu date.
  * Today's menu cannot be ordered after 12:30 Europe/Vienna time.
  * Future dates are never blocked.
  */
 export function isOrderingCutoff(menuDate: Date): boolean {
-  if (!isSameDay(menuDate, new Date())) return false;
+  if (!isSameDay(menuDate, viennaToday())) return false;
   return viennaMinutes() >= 12 * 60 + 30;
 }
 
@@ -92,7 +101,7 @@ export function isOrderingCutoff(menuDate: Date): boolean {
  * Future dates are never blocked.
  */
 export function isCancellationCutoff(orderDate: Date): boolean {
-  if (!isSameDay(orderDate, new Date())) return false;
+  if (!isSameDay(orderDate, viennaToday())) return false;
   return viennaMinutes() >= 9 * 60;
 }
 


### PR DESCRIPTION
## Summary
- Grays out and disables the meal cancel button for today's orders after 09:00 Europe/Vienna time, preventing silent cancellation failures
- Extracts shared `viennaMinutes()` helper from `isOrderingCutoff` and adds `isCancellationCutoff()` following the same pattern
- Adds a store-level guard against concurrent cancellation requests

Fixes #16

## Test plan
- [x] 4 new unit tests for `isCancellationCutoff` (before 9am, at 9am, after 9am, future date)
- [x] All 203 tests passing
- [ ] Visual verification: check cancel button appears grayed out on iOS simulator when cutoff is active
- [ ] Verify cancel button is still functional for future orders and before 9am
- [ ] Verify tapping grayed-out button does nothing (no dialog, no API call)